### PR TITLE
mention arm64 metapackage

### DIFF
--- a/docs/src/nixery.md
+++ b/docs/src/nixery.md
@@ -33,8 +33,10 @@ Each path segment corresponds either to a key in the Nix package set, or a
 meta-package that automatically expands to several other packages.
 
 Meta-packages **must** be the first path component if they are used. Currently
-the only meta-package is `shell`, which provides a `bash`-shell with interactive
-configuration and standard tools like `coreutils`.
+there are only two meta-packages:
+- `shell`, which provides a `bash`-shell with interactive configuration and 
+  standard tools like `coreutils`.
+- `arm64`, which provides ARM64 binaries.
 
 **Tip:** When pulling from a private Nixery instance, replace `nixery.dev` in
 the above examples with your registry address.


### PR DESCRIPTION
Afaict, the arm64 metapackage (discussed in issue #13 ) isn't mentioned anywhere in the docs yet.
I don't know if there are any other metapackages, but arm64 and shell are the only ones I'm aware of.
If there are any more, it might make more sense to move this info to a separate page about metapackages.