### PR TITLE
chore: fix env var name in error message

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ func FromEnv() (Config, error) {
 	default:
 		log.WithField("values", []string{
 			"gcs",
-		}).Fatal("NIXERY_STORAGE_BUCKET must be set to a supported value")
+		}).Fatal("NIXERY_STORAGE_BACKEND must be set to a supported value (gcs or filesystem)")
 	}
 
 	return Config{


### PR DESCRIPTION
The error message shows the wrong variable name, which might
be confusing for new users.

(And to not-so-new users with a flaky memory😅)