### PR TITLE
feat: set SSL_CERT_FILE and provide a Cmd

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -493,7 +493,15 @@ func BuildImage(ctx context.Context, s *State, image *Image) (*BuildResult, erro
 		return nil, err
 	}
 
-	m, c := manifest.Manifest(image.Arch.imageArch, layers)
+	// If the requested packages include a shell,
+	// set cmd accordingly.
+	cmd := ""
+	for _, pkg := range image.Packages {
+		if pkg == "bashInteractive" {
+			cmd = "bash"
+		}
+	}
+	m, c := manifest.Manifest(image.Arch.imageArch, layers, cmd)
 
 	lw := func(w io.Writer) error {
 		r := bytes.NewReader(c.Config)


### PR DESCRIPTION
Two minor "quality of life" improvements:
- automatically set SSL_CERT_FILE environment variable,
  so that programs relying on OpenSSL for certificate
  validation can actually validate certificates
  (the certificates are included no matter what since
  we add the "cacert" package to all images)
- if the requested image includes an interactive shell
  (e.g. if it includes the "shell" metapackage), set
  the image Cmd to "bash", which allows to execute
  "docker run nixery.dev/shell" and get a shell)

I'm happy to split this PR in two if you'd like, but
since both features touch the Config structure and are
rather small, I thought it would make sense to bundle
them together.

To give you a bit more context around this PR:
I've been using Nixery extensively in live demos,
teaching environments, etc. and these have been
the two most confusing items for the students
(number 3 is the lack of /tmp, which I'll try to address
in a future PR).

Related: #101 #133 