### PR TITLE
feat: add /tmp

### DIFF
--- a/prepare-image/prepare-image.nix
+++ b/prepare-image/prepare-image.nix
@@ -133,14 +133,16 @@ let
     name = "bulk-layers";
     paths = allContents.contents;
 
-    # Ensure that there is always a /usr/bin/env for shell scripts
-    # that require it.
+    # Provide a few essentials that many programs expect:
+    # - a /tmp directory,
+    # - a /usr/bin/env for shell scripts that require it.
     #
-    # Note that images which do not actually contain `coreutils` will
-    # still have this symlink, but it will be dangling.
+    # Note that in images that do not actually contain `coreutils`,
+    # /usr/bin/env will be a dangling symlink.
     #
-    # TODO(tazjin): Don't link this if coreutils is not included.
+    # TODO(tazjin): Don't link /usr/bin/env if coreutils is not included.
     postBuild = ''
+      mkdir -p $out/tmp
       mkdir -p $out/usr/bin
       ln -s ${coreutils}/bin/env $out/usr/bin/env
     '';


### PR DESCRIPTION
Hi!

Some programs fail when /tmp doesn't exist:
- terraform
- anything using mktemp and similar helpers

It's trivial to address (just `mkdir /tmp`, or set `TMPDIR`, or mount an ephemeral volume on /tmp) but it would also be nice if stuff like `docker run nixery.dev/shell/terraform` worked out of the box.

Creating /tmp seems super easy; there might be a better place to do it but this one seemed simple enough.

This PR should really be just 1 line; but I updated the comments around it otherwise they wouldn't have quite the same meaning. I hope that's OK; let me know otherwise, happy to tweak/rephrase things!