### PR TITLE
Update GitHub namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 -----------------
 
-[![Build Status](https://github.com/google/nixery/actions/workflows/build-and-test.yaml/badge.svg)](https://github.com/google/nixery/actions/workflows/build-and-test.yaml)
+[![Build Status](https://github.com/tazjin/nixery/actions/workflows/build-and-test.yaml/badge.svg)](https://github.com/tazjin/nixery/actions/workflows/build-and-test.yaml)
 
 **Nixery** is a Docker-compatible container registry that is capable of
 transparently building and serving container images using [Nix][].
@@ -130,7 +130,7 @@ outlined in [a public gist][gist].
 It should be trivial to deploy Nixery inside of a Kubernetes cluster with
 correct caching behaviour, addressing and so on.
 
-See [issue #4](https://github.com/google/nixery/issues/4).
+See [issue #4](https://github.com/tazjin/nixery/issues/4).
 
 ### Nix-native builder
 

--- a/docs/src/nixery.md
+++ b/docs/src/nixery.md
@@ -77,7 +77,7 @@ availability.
 Nixery was written by [tazjin][], but many people have contributed to Nix over
 time, maybe you could become one of them?
 
-[Nixery]: https://github.com/google/nixery
+[Nixery]: https://github.com/tazjin/nixery
 [Nix]: https://nixos.org/nix
 [layering strategy]: https://storage.googleapis.com/nixdoc/nixery-layers.html
 [layers]: https://grahamc.com/blog/nix-and-layered-docker-images

--- a/docs/src/run-your-own.md
+++ b/docs/src/run-your-own.md
@@ -181,10 +181,10 @@ If the directory doesn't exist, Nixery will run fine but serve 404.
     extensively.
 
 [GKE]: https://cloud.google.com/kubernetes-engine/
-[nixery#4]: https://github.com/google/nixery/issues/4
+[nixery#4]: https://github.com/tazjin/nixery/issues/4
 [Nix]: https://nixos.org/nix
 [gcs]: https://cloud.google.com/storage/
-[repo]: https://github.com/google/nixery
+[repo]: https://github.com/tazjin/nixery
 [signed-urls]: under-the-hood.html#5-image-layers-are-requested
 [ADC]: https://cloud.google.com/docs/authentication/production#finding_credentials_automatically
 [nixinstall]: https://nixos.org/manual/nix/stable/installation/installing-binary.html


### PR DESCRIPTION
The Nixery main Git repo has moved from [github.com/**google**/nixery](https://github.com/google/nixery) to [github.com/**tazjin**/nixery](https://github.com/tazjin/nixery).

So change
- respective URL targets in the README
- respective URL targets on the https://nixery.dev/ website
- ~~the package path of the Nixery Go module~~

I'm not quite sure how to test the latter, so I hope CI would catch any breakage this might cause.